### PR TITLE
Support for in.tftpd + qemu GDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,31 +212,27 @@ bios-flash: $(BIOS_FILE) bios-flash-$(PLATFORM)
 # TFTP booting stuff
 # --------------------------------------
 # TFTP server for minisoc to load firmware from
-ATFTPD  := $(shell which atftpd 2>/dev/null)
-INTFTPD := $(shell which in.tftpd 2>/dev/null)
-
 tftp: $(FIRMWARE_FILEBASE).bin
 	mkdir -p $(TFTPD_DIR)
 	cp $(FIRMWARE_FILEBASE).bin $(TFTPD_DIR)/boot.bin
 
 tftpd_stop:
 	sudo true
-ifdef ATFTPD
-	sudo killall atftpd || true	# FIXME: This is dangerous...
-else ifdef INTFTPD
-	sudo killall in.tftpd || true
-endif
+	sudo killall atftpd || sudo killall in.tftpd || true # FIXME: This is dangerous...
 
 tftpd_start:
 	mkdir -p $(TFTPD_DIR)
 	sudo true
-ifdef ATFTPD
-	sudo atftpd --verbose --bind-address $(TFTP_IPRANGE).100 --daemon --logfile /dev/stdout --no-fork --user $(shell whoami) $(TFTPD_DIR) &
-else ifdef INTFTPD
-	sudo in.tftpd --verbose --listen --address $(TFTP_IPRANGE).100 --user $(shell whoami) -s $(TFTPD_DIR) &
-else
-	$(error "Cannot find an appropriate tftpd binary to launch the server.")
-endif
+	@if command -v atftpd >/dev/null ; then \
+		echo "Starting aftpd"; \
+		sudo atftpd --verbose --bind-address $(TFTP_IPRANGE).100 --daemon --logfile /dev/stdout --no-fork --user $(shell whoami) $(TFTPD_DIR) & \
+	elif command -v in.tftpd >/dev/null; then \
+		echo "Starting in.tftpd"; \
+		sudo in.tftpd --verbose --listen --address $(TFTP_IPRANGE).100 --user $(shell whoami) -s $(TFTPD_DIR) & \
+	else \
+		echo "Cannot find an appropriate tftpd binary to launch the server."; \
+		false; \
+	fi
 
 .PHONY: tftp tftpd_stop tftpd_start
 

--- a/scripts/build-qemu.sh
+++ b/scripts/build-qemu.sh
@@ -119,6 +119,9 @@ if grep -q ETHMAC_BASE $TARGET_BUILD_DIR/software/include/generated/csr.h; then
 	EXTRA_ARGS+=("-net nic -net tap,ifname=tap0,script=no,downscript=no")
 fi
 
+# Allow gdb connections
+EXTRA_ARGS+=("-gdb tcp::10001")
+
 SPIFLASH_MODEL=$(grep spiflash_model platforms/$PLATFORM.py | sed -e's/[^"]*"//' -e's/".*$//')
 echo $SPIFLASH_MODEL
 


### PR DESCRIPTION
The atftpd package is not available on fedora.  The default tftpd
package is in.tftpd.  I have been using this and it works fine, although
the logs may not be as nice.

Allow the make file to fall back to use in.tftpd if atftpd is not
available.  Report an error if nothing is available.

Also, enabled gdb in qemu.

These patches were sitting in my environment, now I am going to update to latest hdmi2usb-litex-firmware I wanted to clean them up and push.