### PR TITLE
Make build-qemu work on arch.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ tftpd_start:
 	sudo true
 	@if command -v atftpd >/dev/null ; then \
 		echo "Starting aftpd"; \
-		sudo atftpd --verbose --bind-address $(TFTP_IPRANGE).100 --daemon --logfile /dev/stdout --no-fork --user $(shell whoami) $(TFTPD_DIR) & \
+		sudo atftpd --verbose --bind-address $(TFTP_IPRANGE).100 --daemon --logfile /dev/stdout --no-fork --user $(shell whoami) --group $(shell whoami) $(TFTPD_DIR) & \
 	elif command -v in.tftpd >/dev/null; then \
 		echo "Starting in.tftpd"; \
 		sudo in.tftpd --verbose --listen --address $(TFTP_IPRANGE).100 --user $(shell whoami) -s $(TFTPD_DIR) & \

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -41,10 +41,12 @@ fi
 
 (
 	cd third_party/litex
-	git checkout or1k-linux
+	if [ "$(git rev-parse --abbrev-ref HEAD)" != "or1k-linux" ]; then
+		git checkout or1k-linux
+		cd ../..
+		make gateware
+	fi
 )
-
-make gateware
 
 # Install a toolchain with the newlib standard library
 if ! $CPU-elf-newlib-gcc --version > /dev/null 2>&1; then

--- a/scripts/build-qemu.sh
+++ b/scripts/build-qemu.sh
@@ -118,7 +118,12 @@ if grep -q ETHMAC_BASE $TARGET_BUILD_DIR/software/include/generated/csr.h; then
 		echo "Need to bring up a tun device."
 		IPRANGE=192.168.100
 	        sudo openvpn --mktun --dev tap0
-	        sudo ifconfig tap0 $IPRANGE.100 up
+		if command -v ifconfig >/dev/null ; then
+			sudo ifconfig tap0 $IPRANGE.100 up
+		else
+			sudo ip addr add $IPRANGE.100/24 dev tap0
+			sudo ip link set dev tap0 up
+		fi
 	        sudo mknod /dev/net/tap0 c 10 200
 	        sudo chown $(whoami) /dev/net/tap0
 		make tftpd_start


### PR DESCRIPTION
Use `ip` instead of `ifconfig` if `ifconfig` unavailable.
Set --group for atftpd