### PR TITLE
Use ip not openvpn to create tap0.

### DIFF
--- a/scripts/build-qemu.sh
+++ b/scripts/build-qemu.sh
@@ -117,7 +117,7 @@ if grep -q ETHMAC_BASE $TARGET_BUILD_DIR/software/include/generated/csr.h; then
 	        sudo true
 		echo "Need to bring up a tun device."
 		IPRANGE=192.168.100
-	        sudo openvpn --mktun --dev tap0
+	        sudo ip tuntap add tap0 mode tap
 		if command -v ifconfig >/dev/null ; then
 			sudo ifconfig tap0 $IPRANGE.100 up
 		else


### PR DESCRIPTION
Everyone who has a recent version of the ip tool can use it to create
tap0 --- and it's standard on recent Debian, Ubuntu and CentOS.
Not everyone has UML-tools (tunctl) or openvpn installed.  So use ip
instead of openvpn to instantiate the tun devices.